### PR TITLE
feat: Rover executes character array of commands

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+# Rubocop configuration for Mars Rover kata
+
+AllCops:
+  NewCops: enable
+  SuggestExtensions: false
+  TargetRubyVersion: 3.3
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,13 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 ruby '3.3.1'
+
+group :development do
+  gem 'rubocop', require: false
+end
+
 group :test do
+  gem 'minitest'
   gem 'rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
     diff-lcs (1.6.2)
+    json (2.18.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    minitest (5.16.3)
+    parallel (1.27.0)
+    parser (3.3.10.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.7.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.11.3)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -15,13 +28,33 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.6)
+    rubocop (1.82.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.48.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-24
 
 DEPENDENCIES
+  minitest
   rspec
+  rubocop
 
 RUBY VERSION
    ruby 3.3.1p55

--- a/lib/coordinates.rb
+++ b/lib/coordinates.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Value object representing x,y position on Mars grid
 
 Coordinates = Data.define(:x, :y)

--- a/lib/coordinates.rb
+++ b/lib/coordinates.rb
@@ -1,11 +1,3 @@
-# Represents a position in 2D space
+# Value object representing x,y position on Mars grid
 
-class Coordinates
-  attr_reader :x, :y
-
-  def initialize(x, y)
-    @x = x
-    @y = y
-  end
-end
-
+Coordinates = Data.define(:x, :y)

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -1,9 +1,6 @@
 # Mars Rover - remotely controlled vehicle for Mars exploration
 
-require_relative 'coordinates'
-
 class Rover
-  VALID_DIRECTIONS = %i[north south east west].freeze
 
   attr_reader :direction
 
@@ -26,9 +23,9 @@ class Rover
   private
 
   def validate_direction!(direction)
-    return if VALID_DIRECTIONS.include?(direction)
+    valid_directions = %i[north south east west]
+    return if valid_directions.include?(direction)
 
     raise ArgumentError, "Invalid direction: #{direction}"
   end
 end
-

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 # Mars Rover - remotely controlled vehicle for Mars exploration
 
 class Rover
-
   attr_reader :direction
 
   def initialize(coordinates:, direction:)
-    raise ArgumentError, "Coordinates cannot be nil" if coordinates.nil?
+    raise ArgumentError, 'Coordinates cannot be nil' if coordinates.nil?
 
     validate_direction!(direction)
     @coordinates = coordinates

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -21,6 +21,15 @@ class Rover
     @coordinates.y
   end
 
+  def receive_commands(commands)
+    raise ArgumentError, 'Commands must be an array' unless commands.is_a?(Array)
+
+    valid_commands = %w[f b l r]
+    commands.each do |cmd|
+      raise ArgumentError, "Unsupported command: #{cmd}" unless valid_commands.include?(cmd)
+    end
+  end
+
   private
 
   def validate_direction!(direction)

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -21,7 +21,7 @@ class Rover
     @coordinates.y
   end
 
-  def receive_commands(commands)
+  def execute_commands(commands)
     raise ArgumentError, 'Commands must be an array' unless commands.is_a?(Array)
 
     valid_commands = %w[f b l r]

--- a/spec/coordinates_spec.rb
+++ b/spec/coordinates_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for Coordinates value object
 
 require 'spec_helper'
@@ -20,4 +22,3 @@ RSpec.describe Coordinates do
     end
   end
 end
-

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -45,29 +45,29 @@ RSpec.describe Rover do
   describe 'receiving commands' do
     it 'accepts a character array of commands' do
       rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
-      expect { rover.receive_commands(%w[f b l r]) }.not_to raise_error
+      expect { rover.execute_commands(%w[f b l r]) }.not_to raise_error
     end
 
     it 'accepts an empty array of commands' do
       rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
-      expect { rover.receive_commands([]) }.not_to raise_error
+      expect { rover.execute_commands([]) }.not_to raise_error
     end
 
     it 'rejects nil commands' do
       rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
-      expect { rover.receive_commands(nil) }
+      expect { rover.execute_commands(nil) }
         .to raise_error(ArgumentError, /commands must be an array/i)
     end
 
     it 'rejects non-array commands' do
       rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
-      expect { rover.receive_commands('fblr') }
+      expect { rover.execute_commands('fblr') }
         .to raise_error(ArgumentError, /commands must be an array/i)
     end
 
     it 'rejects unsupported commands' do
       rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
-      expect { rover.receive_commands(%w[f x b]) }
+      expect { rover.execute_commands(%w[f x b]) }
         .to raise_error(ArgumentError, /unsupported command: x/i)
     end
   end

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for Rover initialization and behavior
 
 require 'spec_helper'

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -41,4 +41,34 @@ RSpec.describe Rover do
         .to raise_error(ArgumentError, /coordinates cannot be nil/i)
     end
   end
+
+  describe 'receiving commands' do
+    it 'accepts a character array of commands' do
+      rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+      expect { rover.receive_commands(%w[f b l r]) }.not_to raise_error
+    end
+
+    it 'accepts an empty array of commands' do
+      rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+      expect { rover.receive_commands([]) }.not_to raise_error
+    end
+
+    it 'rejects nil commands' do
+      rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+      expect { rover.receive_commands(nil) }
+        .to raise_error(ArgumentError, /commands must be an array/i)
+    end
+
+    it 'rejects non-array commands' do
+      rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+      expect { rover.receive_commands('fblr') }
+        .to raise_error(ArgumentError, /commands must be an array/i)
+    end
+
+    it 'rejects unsupported commands' do
+      rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+      expect { rover.receive_commands(%w[f x b]) }
+        .to raise_error(ArgumentError, /unsupported command: x/i)
+    end
+  end
 end

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -1,6 +1,7 @@
 # Tests for Rover initialization and behavior
 
 require 'spec_helper'
+require_relative '../lib/coordinates'
 require_relative '../lib/rover'
 
 RSpec.describe Rover do
@@ -39,4 +40,3 @@ RSpec.describe Rover do
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# RSpec configuration for Mars Rover kata
+# RSpec configuration for Mars Rover tests
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -10,5 +10,4 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
-  config.fail_fast = false
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # RSpec configuration for Mars Rover tests
 
 RSpec.configure do |config|


### PR DESCRIPTION
Adds execute_commands method to Rover:
- Accepts array of command characters (f, b, l, r)
- Validates input is an array
- Rejects unsupported commands with clear error message

Builds on feature-1 which includes rubocop linter and pre-commit hooks.