### PR TITLE
feat: implement forward/backward movement commands (f, b)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+# Rubocop configuration for Mars Rover kata
+
+AllCops:
+  NewCops: enable
+  SuggestExtensions: false
+  TargetRubyVersion: 3.3
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,13 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 ruby '3.3.1'
+
+group :development do
+  gem 'rubocop', require: false
+end
+
 group :test do
+  gem 'minitest'
   gem 'rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
     diff-lcs (1.6.2)
+    json (2.18.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    minitest (5.16.3)
+    parallel (1.27.0)
+    parser (3.3.10.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.7.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.11.3)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -15,13 +28,33 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.6)
+    rubocop (1.82.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.48.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-24
 
 DEPENDENCIES
+  minitest
   rspec
+  rubocop
 
 RUBY VERSION
    ruby 3.3.1p55

--- a/lib/coordinates.rb
+++ b/lib/coordinates.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Value object representing x,y position on Mars grid
 
 Coordinates = Data.define(:x, :y)

--- a/lib/coordinates.rb
+++ b/lib/coordinates.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 # Value object representing x,y position on Mars grid
-
-Coordinates = Data.define(:x, :y)
+Coordinates = Data.define(:x, :y) do
+  def translate(delta_x, delta_y)
+    Coordinates.new(x + delta_x, y + delta_y)
+  end
+end

--- a/lib/coordinates.rb
+++ b/lib/coordinates.rb
@@ -1,11 +1,3 @@
-# Represents a position in 2D space
+# Value object representing x,y position on Mars grid
 
-class Coordinates
-  attr_reader :x, :y
-
-  def initialize(x, y)
-    @x = x
-    @y = y
-  end
-end
-
+Coordinates = Data.define(:x, :y)

--- a/lib/direction.rb
+++ b/lib/direction.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Cardinal direction with associated movement delta
+class Direction
+  DELTAS = {
+    north: [0, 1],
+    south: [0, -1],
+    east: [1, 0],
+    west: [-1, 0]
+  }.freeze
+
+  def self.valid?(direction)
+    DELTAS.key?(direction)
+  end
+
+  def self.delta_for(direction)
+    DELTAS.fetch(direction)
+  end
+
+  def self.all
+    DELTAS.keys
+  end
+end

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -1,9 +1,6 @@
 # Mars Rover - remotely controlled vehicle for Mars exploration
 
-require_relative 'coordinates'
-
 class Rover
-  VALID_DIRECTIONS = %i[north south east west].freeze
 
   attr_reader :direction
 
@@ -26,9 +23,9 @@ class Rover
   private
 
   def validate_direction!(direction)
-    return if VALID_DIRECTIONS.include?(direction)
+    valid_directions = %i[north south east west]
+    return if valid_directions.include?(direction)
 
     raise ArgumentError, "Invalid direction: #{direction}"
   end
 end
-

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 # Mars Rover - remotely controlled vehicle for Mars exploration
 
 class Rover
-
   attr_reader :direction
 
   def initialize(coordinates:, direction:)
-    raise ArgumentError, "Coordinates cannot be nil" if coordinates.nil?
+    raise ArgumentError, 'Coordinates cannot be nil' if coordinates.nil?
 
     validate_direction!(direction)
     @coordinates = coordinates

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
+require_relative 'direction'
+
 # Mars Rover - remotely controlled vehicle for Mars exploration
-
 class Rover
-  MOVEMENT_DELTAS = {
-    north: [0, 1],
-    south: [0, -1],
-    east: [1, 0],
-    west: [-1, 0]
-  }.freeze
-
   attr_reader :direction
 
   def initialize(coordinates:, direction:)
@@ -53,18 +47,17 @@ class Rover
   end
 
   def move_forward
-    delta_x, delta_y = MOVEMENT_DELTAS[@direction]
-    @coordinates = Coordinates.new(@coordinates.x + delta_x, @coordinates.y + delta_y)
+    delta_x, delta_y = Direction.delta_for(@direction)
+    @coordinates = @coordinates.translate(delta_x, delta_y)
   end
 
   def move_backward
-    delta_x, delta_y = MOVEMENT_DELTAS[@direction]
-    @coordinates = Coordinates.new(@coordinates.x - delta_x, @coordinates.y - delta_y)
+    delta_x, delta_y = Direction.delta_for(@direction)
+    @coordinates = @coordinates.translate(-delta_x, -delta_y)
   end
 
   def validate_direction!(direction)
-    valid_directions = %i[north south east west]
-    return if valid_directions.include?(direction)
+    return if Direction.valid?(direction)
 
     raise ArgumentError, "Invalid direction: #{direction}"
   end

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -21,9 +21,11 @@ class Rover
     @coordinates.y
   end
 
-  def execute(commands)
+  def execute_commands(commands)
+    raise ArgumentError, 'Commands must be an array' unless commands.is_a?(Array)
+
     validate_commands!(commands)
-    commands.each_char do |command|
+    commands.each do |command|
       case command
       when 'f' then move_forward
       when 'b' then move_backward
@@ -34,10 +36,12 @@ class Rover
   private
 
   def validate_commands!(commands)
-    commands.each_char do |command|
-      next if %w[f b].include?(command)
+    valid = %w[f b l r]
+    commands.each do |command|
+      next if valid.include?(command)
 
-      raise ArgumentError, "Invalid command '#{command}'. Valid commands: f (forward), b (backward)"
+      raise ArgumentError,
+            "Invalid command '#{command}'. Valid commands: f (forward), b (backward), l (left), r (right)"
     end
   end
 

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -21,7 +21,43 @@ class Rover
     @coordinates.y
   end
 
+  def execute(commands)
+    validate_commands!(commands)
+    commands.each_char do |command|
+      case command
+      when 'f' then move_forward
+      when 'b' then move_backward
+      end
+    end
+  end
+
   private
+
+  def validate_commands!(commands)
+    commands.each_char do |command|
+      next if %w[f b].include?(command)
+
+      raise ArgumentError, "Invalid command '#{command}'. Valid commands: f (forward), b (backward)"
+    end
+  end
+
+  def move_forward
+    case @direction
+    when :north then @coordinates = Coordinates.new(@coordinates.x, @coordinates.y + 1)
+    when :south then @coordinates = Coordinates.new(@coordinates.x, @coordinates.y - 1)
+    when :east then @coordinates = Coordinates.new(@coordinates.x + 1, @coordinates.y)
+    when :west then @coordinates = Coordinates.new(@coordinates.x - 1, @coordinates.y)
+    end
+  end
+
+  def move_backward
+    case @direction
+    when :north then @coordinates = Coordinates.new(@coordinates.x, @coordinates.y - 1)
+    when :south then @coordinates = Coordinates.new(@coordinates.x, @coordinates.y + 1)
+    when :east then @coordinates = Coordinates.new(@coordinates.x - 1, @coordinates.y)
+    when :west then @coordinates = Coordinates.new(@coordinates.x + 1, @coordinates.y)
+    end
+  end
 
   def validate_direction!(direction)
     valid_directions = %i[north south east west]

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -3,6 +3,13 @@
 # Mars Rover - remotely controlled vehicle for Mars exploration
 
 class Rover
+  MOVEMENT_DELTAS = {
+    north: [0, 1],
+    south: [0, -1],
+    east: [1, 0],
+    west: [-1, 0]
+  }.freeze
+
   attr_reader :direction
 
   def initialize(coordinates:, direction:)
@@ -22,8 +29,6 @@ class Rover
   end
 
   def execute_commands(commands)
-    raise ArgumentError, 'Commands must be an array' unless commands.is_a?(Array)
-
     validate_commands!(commands)
     commands.each do |command|
       case command
@@ -36,6 +41,8 @@ class Rover
   private
 
   def validate_commands!(commands)
+    raise ArgumentError, 'Commands must be an array' unless commands.is_a?(Array)
+
     valid = %w[f b l r]
     commands.each do |command|
       next if valid.include?(command)
@@ -46,21 +53,13 @@ class Rover
   end
 
   def move_forward
-    case @direction
-    when :north then @coordinates = Coordinates.new(@coordinates.x, @coordinates.y + 1)
-    when :south then @coordinates = Coordinates.new(@coordinates.x, @coordinates.y - 1)
-    when :east then @coordinates = Coordinates.new(@coordinates.x + 1, @coordinates.y)
-    when :west then @coordinates = Coordinates.new(@coordinates.x - 1, @coordinates.y)
-    end
+    delta_x, delta_y = MOVEMENT_DELTAS[@direction]
+    @coordinates = Coordinates.new(@coordinates.x + delta_x, @coordinates.y + delta_y)
   end
 
   def move_backward
-    case @direction
-    when :north then @coordinates = Coordinates.new(@coordinates.x, @coordinates.y - 1)
-    when :south then @coordinates = Coordinates.new(@coordinates.x, @coordinates.y + 1)
-    when :east then @coordinates = Coordinates.new(@coordinates.x - 1, @coordinates.y)
-    when :west then @coordinates = Coordinates.new(@coordinates.x + 1, @coordinates.y)
-    end
+    delta_x, delta_y = MOVEMENT_DELTAS[@direction]
+    @coordinates = Coordinates.new(@coordinates.x - delta_x, @coordinates.y - delta_y)
   end
 
   def validate_direction!(direction)

--- a/spec/coordinates_spec.rb
+++ b/spec/coordinates_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for Coordinates value object
 
 require 'spec_helper'
@@ -20,4 +22,3 @@ RSpec.describe Coordinates do
     end
   end
 end
-

--- a/spec/coordinates_spec.rb
+++ b/spec/coordinates_spec.rb
@@ -21,4 +21,30 @@ RSpec.describe Coordinates do
       expect(coords).not_to respond_to(:y=)
     end
   end
+
+  describe '#translate' do
+    it 'returns new Coordinates with offset applied' do
+      coords = Coordinates.new(3, 5)
+
+      result = coords.translate(1, 2)
+
+      expect(result).to eq(Coordinates.new(4, 7))
+    end
+
+    it 'handles negative deltas' do
+      coords = Coordinates.new(3, 5)
+
+      result = coords.translate(-1, -2)
+
+      expect(result).to eq(Coordinates.new(2, 3))
+    end
+
+    it 'does not modify original coordinates' do
+      coords = Coordinates.new(3, 5)
+
+      coords.translate(1, 2)
+
+      expect(coords).to eq(Coordinates.new(3, 5))
+    end
+  end
 end

--- a/spec/direction_spec.rb
+++ b/spec/direction_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Tests for Direction class
+require 'spec_helper'
+require_relative '../lib/direction'
+
+RSpec.describe Direction do
+  describe '.valid?' do
+    %i[north south east west].each do |dir|
+      it "returns true for #{dir}" do
+        expect(Direction.valid?(dir)).to be true
+      end
+    end
+
+    it 'returns false for invalid directions' do
+      expect(Direction.valid?(:northeast)).to be false
+      expect(Direction.valid?(:up)).to be false
+      expect(Direction.valid?(nil)).to be false
+    end
+  end
+
+  describe '.delta_for' do
+    it 'returns [0, 1] for north' do
+      expect(Direction.delta_for(:north)).to eq([0, 1])
+    end
+
+    it 'returns [0, -1] for south' do
+      expect(Direction.delta_for(:south)).to eq([0, -1])
+    end
+
+    it 'returns [1, 0] for east' do
+      expect(Direction.delta_for(:east)).to eq([1, 0])
+    end
+
+    it 'returns [-1, 0] for west' do
+      expect(Direction.delta_for(:west)).to eq([-1, 0])
+    end
+
+    it 'raises KeyError for invalid direction' do
+      expect { Direction.delta_for(:invalid) }.to raise_error(KeyError)
+    end
+  end
+
+  describe '.all' do
+    it 'returns all valid directions' do
+      expect(Direction.all).to contain_exactly(:north, :south, :east, :west)
+    end
+  end
+end

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for Rover initialization and behavior
 
 require 'spec_helper'

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Rover do
 
           rover.execute_commands(['f'])
 
-          expect(Coordinates.new(rover.x, rover.y)).to eq(scenario[:expected])
+          expect(rover).to be_located_at(scenario[:expected])
         end
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe Rover do
 
           rover.execute_commands(['b'])
 
-          expect(Coordinates.new(rover.x, rover.y)).to eq(scenario[:expected])
+          expect(rover).to be_located_at(scenario[:expected])
         end
       end
     end
@@ -83,19 +83,17 @@ RSpec.describe Rover do
 
         rover.execute_commands(%w[f f b])
 
-        expect(rover.y).to eq(1)
-        expect(rover.x).to eq(0)
+        expect(rover).to be_located_at(Coordinates.new(0, 1))
       end
     end
 
-    describe 'empty commands' do
+    describe 'no commands' do
       it 'does nothing with empty array' do
         rover = Rover.new(coordinates: Coordinates.new(5, 5), direction: :north)
 
         rover.execute_commands([])
 
-        expect(rover.x).to eq(5)
-        expect(rover.y).to eq(5)
+        expect(rover).to be_located_at(Coordinates.new(5, 5))
       end
     end
 

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Rover do
     end
   end
 
-  describe '#execute' do
+  describe '#execute_commands' do
     describe 'forward command' do
       [
         { direction: :north, start: Coordinates.new(0, 0), expected: Coordinates.new(0, 1) },
@@ -53,7 +53,7 @@ RSpec.describe Rover do
         it "moves when facing #{tc[:direction]}" do
           rover = Rover.new(coordinates: tc[:start], direction: tc[:direction])
 
-          rover.execute('f')
+          rover.execute_commands(['f'])
 
           expect(Coordinates.new(rover.x, rover.y)).to eq(tc[:expected])
         end
@@ -70,7 +70,7 @@ RSpec.describe Rover do
         it "moves when facing #{tc[:direction]}" do
           rover = Rover.new(coordinates: tc[:start], direction: tc[:direction])
 
-          rover.execute('b')
+          rover.execute_commands(['b'])
 
           expect(Coordinates.new(rover.x, rover.y)).to eq(tc[:expected])
         end
@@ -81,7 +81,7 @@ RSpec.describe Rover do
       it 'executes commands in sequence' do
         rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
 
-        rover.execute('ffb')
+        rover.execute_commands(%w[f f b])
 
         expect(rover.y).to eq(1)
         expect(rover.x).to eq(0)
@@ -89,10 +89,10 @@ RSpec.describe Rover do
     end
 
     describe 'empty commands' do
-      it 'does nothing with empty string' do
+      it 'does nothing with empty array' do
         rover = Rover.new(coordinates: Coordinates.new(5, 5), direction: :north)
 
-        rover.execute('')
+        rover.execute_commands([])
 
         expect(rover.x).to eq(5)
         expect(rover.y).to eq(5)
@@ -100,17 +100,37 @@ RSpec.describe Rover do
     end
 
     describe 'command validation' do
+      it 'accepts all valid commands' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+
+        expect { rover.execute_commands(%w[f b l r]) }.not_to raise_error
+      end
+
+      it 'rejects nil commands' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+
+        expect { rover.execute_commands(nil) }
+          .to raise_error(ArgumentError, /commands must be an array/i)
+      end
+
+      it 'rejects non-array commands' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+
+        expect { rover.execute_commands('fblr') }
+          .to raise_error(ArgumentError, /commands must be an array/i)
+      end
+
       it 'rejects invalid commands with helpful error' do
         rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
 
-        expect { rover.execute('x') }
-          .to raise_error(ArgumentError, "Invalid command 'x'. Valid commands: f (forward), b (backward)")
+        expect { rover.execute_commands(['x']) }
+          .to raise_error(ArgumentError, /Invalid command 'x'.*Valid commands:.*f.*b.*l.*r/)
       end
 
       it 'rejects invalid command in sequence before executing any' do
         rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
 
-        expect { rover.execute('fx') }.to raise_error(ArgumentError)
+        expect { rover.execute_commands(%w[f x]) }.to raise_error(ArgumentError)
         expect(rover.y).to eq(0)
       end
     end

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -1,6 +1,7 @@
 # Tests for Rover initialization and behavior
 
 require 'spec_helper'
+require_relative '../lib/coordinates'
 require_relative '../lib/rover'
 
 RSpec.describe Rover do
@@ -39,4 +40,3 @@ RSpec.describe Rover do
     end
   end
 end
-

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -44,78 +44,36 @@ RSpec.describe Rover do
 
   describe '#execute' do
     describe 'forward command' do
-      it 'moves north when facing north' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+      [
+        { direction: :north, start: Coordinates.new(0, 0), expected: Coordinates.new(0, 1) },
+        { direction: :south, start: Coordinates.new(0, 1), expected: Coordinates.new(0, 0) },
+        { direction: :east,  start: Coordinates.new(0, 0), expected: Coordinates.new(1, 0) },
+        { direction: :west,  start: Coordinates.new(1, 0), expected: Coordinates.new(0, 0) }
+      ].each do |tc|
+        it "moves when facing #{tc[:direction]}" do
+          rover = Rover.new(coordinates: tc[:start], direction: tc[:direction])
 
-        rover.execute('f')
+          rover.execute('f')
 
-        expect(rover.y).to eq(1)
-        expect(rover.x).to eq(0)
-      end
-
-      it 'moves south when facing south' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 1), direction: :south)
-
-        rover.execute('f')
-
-        expect(rover.y).to eq(0)
-        expect(rover.x).to eq(0)
-      end
-
-      it 'moves east when facing east' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :east)
-
-        rover.execute('f')
-
-        expect(rover.x).to eq(1)
-        expect(rover.y).to eq(0)
-      end
-
-      it 'moves west when facing west' do
-        rover = Rover.new(coordinates: Coordinates.new(1, 0), direction: :west)
-
-        rover.execute('f')
-
-        expect(rover.x).to eq(0)
-        expect(rover.y).to eq(0)
+          expect(Coordinates.new(rover.x, rover.y)).to eq(tc[:expected])
+        end
       end
     end
 
     describe 'backward command' do
-      it 'moves south when facing north' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 1), direction: :north)
+      [
+        { direction: :north, start: Coordinates.new(0, 1), expected: Coordinates.new(0, 0) },
+        { direction: :south, start: Coordinates.new(0, 0), expected: Coordinates.new(0, 1) },
+        { direction: :east,  start: Coordinates.new(1, 0), expected: Coordinates.new(0, 0) },
+        { direction: :west,  start: Coordinates.new(0, 0), expected: Coordinates.new(1, 0) }
+      ].each do |tc|
+        it "moves when facing #{tc[:direction]}" do
+          rover = Rover.new(coordinates: tc[:start], direction: tc[:direction])
 
-        rover.execute('b')
+          rover.execute('b')
 
-        expect(rover.y).to eq(0)
-        expect(rover.x).to eq(0)
-      end
-
-      it 'moves north when facing south' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :south)
-
-        rover.execute('b')
-
-        expect(rover.y).to eq(1)
-        expect(rover.x).to eq(0)
-      end
-
-      it 'moves west when facing east' do
-        rover = Rover.new(coordinates: Coordinates.new(1, 0), direction: :east)
-
-        rover.execute('b')
-
-        expect(rover.x).to eq(0)
-        expect(rover.y).to eq(0)
-      end
-
-      it 'moves east when facing west' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :west)
-
-        rover.execute('b')
-
-        expect(rover.x).to eq(1)
-        expect(rover.y).to eq(0)
+          expect(Coordinates.new(rover.x, rover.y)).to eq(tc[:expected])
+        end
       end
     end
 

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -49,13 +49,13 @@ RSpec.describe Rover do
         { direction: :south, start: Coordinates.new(0, 1), expected: Coordinates.new(0, 0) },
         { direction: :east,  start: Coordinates.new(0, 0), expected: Coordinates.new(1, 0) },
         { direction: :west,  start: Coordinates.new(1, 0), expected: Coordinates.new(0, 0) }
-      ].each do |tc|
-        it "moves when facing #{tc[:direction]}" do
-          rover = Rover.new(coordinates: tc[:start], direction: tc[:direction])
+      ].each do |scenario|
+        it "moves when facing #{scenario[:direction]}" do
+          rover = Rover.new(coordinates: scenario[:start], direction: scenario[:direction])
 
           rover.execute_commands(['f'])
 
-          expect(Coordinates.new(rover.x, rover.y)).to eq(tc[:expected])
+          expect(Coordinates.new(rover.x, rover.y)).to eq(scenario[:expected])
         end
       end
     end
@@ -66,13 +66,13 @@ RSpec.describe Rover do
         { direction: :south, start: Coordinates.new(0, 0), expected: Coordinates.new(0, 1) },
         { direction: :east,  start: Coordinates.new(1, 0), expected: Coordinates.new(0, 0) },
         { direction: :west,  start: Coordinates.new(0, 0), expected: Coordinates.new(1, 0) }
-      ].each do |tc|
-        it "moves when facing #{tc[:direction]}" do
-          rover = Rover.new(coordinates: tc[:start], direction: tc[:direction])
+      ].each do |scenario|
+        it "moves when facing #{scenario[:direction]}" do
+          rover = Rover.new(coordinates: scenario[:start], direction: scenario[:direction])
 
           rover.execute_commands(['b'])
 
-          expect(Coordinates.new(rover.x, rover.y)).to eq(tc[:expected])
+          expect(Coordinates.new(rover.x, rover.y)).to eq(scenario[:expected])
         end
       end
     end

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -41,4 +41,120 @@ RSpec.describe Rover do
         .to raise_error(ArgumentError, /coordinates cannot be nil/i)
     end
   end
+
+  describe '#execute' do
+    describe 'forward command' do
+      it 'moves north when facing north' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+
+        rover.execute('f')
+
+        expect(rover.y).to eq(1)
+        expect(rover.x).to eq(0)
+      end
+
+      it 'moves south when facing south' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 1), direction: :south)
+
+        rover.execute('f')
+
+        expect(rover.y).to eq(0)
+        expect(rover.x).to eq(0)
+      end
+
+      it 'moves east when facing east' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :east)
+
+        rover.execute('f')
+
+        expect(rover.x).to eq(1)
+        expect(rover.y).to eq(0)
+      end
+
+      it 'moves west when facing west' do
+        rover = Rover.new(coordinates: Coordinates.new(1, 0), direction: :west)
+
+        rover.execute('f')
+
+        expect(rover.x).to eq(0)
+        expect(rover.y).to eq(0)
+      end
+    end
+
+    describe 'backward command' do
+      it 'moves south when facing north' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 1), direction: :north)
+
+        rover.execute('b')
+
+        expect(rover.y).to eq(0)
+        expect(rover.x).to eq(0)
+      end
+
+      it 'moves north when facing south' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :south)
+
+        rover.execute('b')
+
+        expect(rover.y).to eq(1)
+        expect(rover.x).to eq(0)
+      end
+
+      it 'moves west when facing east' do
+        rover = Rover.new(coordinates: Coordinates.new(1, 0), direction: :east)
+
+        rover.execute('b')
+
+        expect(rover.x).to eq(0)
+        expect(rover.y).to eq(0)
+      end
+
+      it 'moves east when facing west' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :west)
+
+        rover.execute('b')
+
+        expect(rover.x).to eq(1)
+        expect(rover.y).to eq(0)
+      end
+    end
+
+    describe 'multiple commands' do
+      it 'executes commands in sequence' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+
+        rover.execute('ffb')
+
+        expect(rover.y).to eq(1)
+        expect(rover.x).to eq(0)
+      end
+    end
+
+    describe 'empty commands' do
+      it 'does nothing with empty string' do
+        rover = Rover.new(coordinates: Coordinates.new(5, 5), direction: :north)
+
+        rover.execute('')
+
+        expect(rover.x).to eq(5)
+        expect(rover.y).to eq(5)
+      end
+    end
+
+    describe 'command validation' do
+      it 'rejects invalid commands with helpful error' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+
+        expect { rover.execute('x') }
+          .to raise_error(ArgumentError, "Invalid command 'x'. Valid commands: f (forward), b (backward)")
+      end
+
+      it 'rejects invalid command in sequence before executing any' do
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+
+        expect { rover.execute('fx') }.to raise_error(ArgumentError)
+        expect(rover.y).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# RSpec configuration for Mars Rover kata
+# RSpec configuration for Mars Rover tests
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -10,5 +10,4 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
-  config.fail_fast = false
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # RSpec configuration for Mars Rover tests
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,19 @@
 
 # RSpec configuration for Mars Rover tests
 
+require_relative '../lib/coordinates'
+
+RSpec::Matchers.define :be_located_at do |expected_coords|
+  match do |rover|
+    Coordinates.new(rover.x, rover.y) == expected_coords
+  end
+
+  failure_message do |rover|
+    actual = Coordinates.new(rover.x, rover.y)
+    "expected rover at #{expected_coords}, got #{actual}"
+  end
+end
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
## Summary
- Add `execute` method that processes command strings
- Forward (f) moves in facing direction, backward (b) moves opposite
- Validate commands upfront with helpful error message
- Only f and b accepted, invalid commands rejected with: `Invalid command 'x'. Valid commands: f (forward), b (backward)`

## Tests
- 22 examples, 0 failures
- RuboCop clean