### PR TITLE
refactor: inject Direction objects into Rover via dependency injection

### DIFF
--- a/lib/direction.rb
+++ b/lib/direction.rb
@@ -2,22 +2,20 @@
 
 # Cardinal direction with associated movement delta
 class Direction
-  DELTAS = {
-    north: [0, 1],
-    south: [0, -1],
-    east: [1, 0],
-    west: [-1, 0]
-  }.freeze
+  attr_reader :delta
 
-  def self.valid?(direction)
-    DELTAS.key?(direction)
+  private_class_method :new
+
+  def initialize(delta)
+    @delta = delta
   end
 
-  def self.delta_for(direction)
-    DELTAS.fetch(direction)
-  end
+  NORTH = new([0, 1]).freeze
+  SOUTH = new([0, -1]).freeze
+  EAST = new([1, 0]).freeze
+  WEST = new([-1, 0]).freeze
 
   def self.all
-    DELTAS.keys
+    [NORTH, SOUTH, EAST, WEST]
   end
 end

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'direction'
-
 # Mars Rover - remotely controlled vehicle for Mars exploration
 class Rover
   attr_reader :direction
@@ -9,7 +7,6 @@ class Rover
   def initialize(coordinates:, direction:)
     raise ArgumentError, 'Coordinates cannot be nil' if coordinates.nil?
 
-    validate_direction!(direction)
     @coordinates = coordinates
     @direction = direction
   end
@@ -47,18 +44,12 @@ class Rover
   end
 
   def move_forward
-    delta_x, delta_y = Direction.delta_for(@direction)
+    delta_x, delta_y = @direction.delta
     @coordinates = @coordinates.translate(delta_x, delta_y)
   end
 
   def move_backward
-    delta_x, delta_y = Direction.delta_for(@direction)
+    delta_x, delta_y = @direction.delta
     @coordinates = @coordinates.translate(-delta_x, -delta_y)
-  end
-
-  def validate_direction!(direction)
-    return if Direction.valid?(direction)
-
-    raise ArgumentError, "Invalid direction: #{direction}"
   end
 end

--- a/spec/direction_spec.rb
+++ b/spec/direction_spec.rb
@@ -5,45 +5,38 @@ require 'spec_helper'
 require_relative '../lib/direction'
 
 RSpec.describe Direction do
-  describe '.valid?' do
-    %i[north south east west].each do |dir|
-      it "returns true for #{dir}" do
-        expect(Direction.valid?(dir)).to be true
-      end
+  describe 'delta' do
+    it 'returns [0, 1] for NORTH' do
+      expect(Direction::NORTH.delta).to eq([0, 1])
     end
 
-    it 'returns false for invalid directions' do
-      expect(Direction.valid?(:northeast)).to be false
-      expect(Direction.valid?(:up)).to be false
-      expect(Direction.valid?(nil)).to be false
-    end
-  end
-
-  describe '.delta_for' do
-    it 'returns [0, 1] for north' do
-      expect(Direction.delta_for(:north)).to eq([0, 1])
+    it 'returns [0, -1] for SOUTH' do
+      expect(Direction::SOUTH.delta).to eq([0, -1])
     end
 
-    it 'returns [0, -1] for south' do
-      expect(Direction.delta_for(:south)).to eq([0, -1])
+    it 'returns [1, 0] for EAST' do
+      expect(Direction::EAST.delta).to eq([1, 0])
     end
 
-    it 'returns [1, 0] for east' do
-      expect(Direction.delta_for(:east)).to eq([1, 0])
-    end
-
-    it 'returns [-1, 0] for west' do
-      expect(Direction.delta_for(:west)).to eq([-1, 0])
-    end
-
-    it 'raises KeyError for invalid direction' do
-      expect { Direction.delta_for(:invalid) }.to raise_error(KeyError)
+    it 'returns [-1, 0] for WEST' do
+      expect(Direction::WEST.delta).to eq([-1, 0])
     end
   end
 
   describe '.all' do
-    it 'returns all valid directions' do
-      expect(Direction.all).to contain_exactly(:north, :south, :east, :west)
+    it 'returns all direction instances' do
+      expect(Direction.all).to contain_exactly(
+        Direction::NORTH,
+        Direction::SOUTH,
+        Direction::EAST,
+        Direction::WEST
+      )
+    end
+  end
+
+  describe 'private constructor' do
+    it 'prevents creating arbitrary instances' do
+      expect { Direction.new([0, 0]) }.to raise_error(NoMethodError)
     end
   end
 end

--- a/spec/rover_spec.rb
+++ b/spec/rover_spec.rb
@@ -4,40 +4,41 @@
 
 require 'spec_helper'
 require_relative '../lib/coordinates'
+require_relative '../lib/direction'
 require_relative '../lib/rover'
 
 RSpec.describe Rover do
   describe 'initialization' do
     it 'creates a rover with position and direction' do
-      rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+      rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: Direction::NORTH)
 
       expect(rover.x).to eq(0)
       expect(rover.y).to eq(0)
-      expect(rover.direction).to eq(:north)
+      expect(rover.direction).to eq(Direction::NORTH)
     end
 
     it 'accepts any valid starting position' do
-      rover = Rover.new(coordinates: Coordinates.new(5, 3), direction: :east)
+      rover = Rover.new(coordinates: Coordinates.new(5, 3), direction: Direction::EAST)
 
       expect(rover.x).to eq(5)
       expect(rover.y).to eq(3)
-      expect(rover.direction).to eq(:east)
+      expect(rover.direction).to eq(Direction::EAST)
     end
 
-    %i[north south east west].each do |dir|
-      it "accepts #{dir} as a valid direction" do
+    [
+      Direction::NORTH,
+      Direction::SOUTH,
+      Direction::EAST,
+      Direction::WEST
+    ].each do |dir|
+      it "accepts #{dir.delta} direction" do
         rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: dir)
         expect(rover.direction).to eq(dir)
       end
     end
 
-    it 'rejects invalid directions' do
-      expect { Rover.new(coordinates: Coordinates.new(0, 0), direction: :northeast) }
-        .to raise_error(ArgumentError, /invalid direction/i)
-    end
-
     it 'rejects nil coordinates' do
-      expect { Rover.new(coordinates: nil, direction: :north) }
+      expect { Rover.new(coordinates: nil, direction: Direction::NORTH) }
         .to raise_error(ArgumentError, /coordinates cannot be nil/i)
     end
   end
@@ -45,12 +46,12 @@ RSpec.describe Rover do
   describe '#execute_commands' do
     describe 'forward command' do
       [
-        { direction: :north, start: Coordinates.new(0, 0), expected: Coordinates.new(0, 1) },
-        { direction: :south, start: Coordinates.new(0, 1), expected: Coordinates.new(0, 0) },
-        { direction: :east,  start: Coordinates.new(0, 0), expected: Coordinates.new(1, 0) },
-        { direction: :west,  start: Coordinates.new(1, 0), expected: Coordinates.new(0, 0) }
+        { direction: Direction::NORTH, start: Coordinates.new(0, 0), expected: Coordinates.new(0, 1) },
+        { direction: Direction::SOUTH, start: Coordinates.new(0, 1), expected: Coordinates.new(0, 0) },
+        { direction: Direction::EAST,  start: Coordinates.new(0, 0), expected: Coordinates.new(1, 0) },
+        { direction: Direction::WEST,  start: Coordinates.new(1, 0), expected: Coordinates.new(0, 0) }
       ].each do |scenario|
-        it "moves when facing #{scenario[:direction]}" do
+        it "moves when facing #{scenario[:direction].delta}" do
           rover = Rover.new(coordinates: scenario[:start], direction: scenario[:direction])
 
           rover.execute_commands(['f'])
@@ -62,12 +63,12 @@ RSpec.describe Rover do
 
     describe 'backward command' do
       [
-        { direction: :north, start: Coordinates.new(0, 1), expected: Coordinates.new(0, 0) },
-        { direction: :south, start: Coordinates.new(0, 0), expected: Coordinates.new(0, 1) },
-        { direction: :east,  start: Coordinates.new(1, 0), expected: Coordinates.new(0, 0) },
-        { direction: :west,  start: Coordinates.new(0, 0), expected: Coordinates.new(1, 0) }
+        { direction: Direction::NORTH, start: Coordinates.new(0, 1), expected: Coordinates.new(0, 0) },
+        { direction: Direction::SOUTH, start: Coordinates.new(0, 0), expected: Coordinates.new(0, 1) },
+        { direction: Direction::EAST,  start: Coordinates.new(1, 0), expected: Coordinates.new(0, 0) },
+        { direction: Direction::WEST,  start: Coordinates.new(0, 0), expected: Coordinates.new(1, 0) }
       ].each do |scenario|
-        it "moves when facing #{scenario[:direction]}" do
+        it "moves when facing #{scenario[:direction].delta}" do
           rover = Rover.new(coordinates: scenario[:start], direction: scenario[:direction])
 
           rover.execute_commands(['b'])
@@ -79,7 +80,7 @@ RSpec.describe Rover do
 
     describe 'multiple commands' do
       it 'executes commands in sequence' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: Direction::NORTH)
 
         rover.execute_commands(%w[f f b])
 
@@ -89,7 +90,7 @@ RSpec.describe Rover do
 
     describe 'no commands' do
       it 'does nothing with empty array' do
-        rover = Rover.new(coordinates: Coordinates.new(5, 5), direction: :north)
+        rover = Rover.new(coordinates: Coordinates.new(5, 5), direction: Direction::NORTH)
 
         rover.execute_commands([])
 
@@ -99,34 +100,34 @@ RSpec.describe Rover do
 
     describe 'command validation' do
       it 'accepts all valid commands' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: Direction::NORTH)
 
         expect { rover.execute_commands(%w[f b l r]) }.not_to raise_error
       end
 
       it 'rejects nil commands' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: Direction::NORTH)
 
         expect { rover.execute_commands(nil) }
           .to raise_error(ArgumentError, /commands must be an array/i)
       end
 
       it 'rejects non-array commands' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: Direction::NORTH)
 
         expect { rover.execute_commands('fblr') }
           .to raise_error(ArgumentError, /commands must be an array/i)
       end
 
       it 'rejects invalid commands with helpful error' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: Direction::NORTH)
 
         expect { rover.execute_commands(['x']) }
           .to raise_error(ArgumentError, /Invalid command 'x'.*Valid commands:.*f.*b.*l.*r/)
       end
 
       it 'rejects invalid command in sequence before executing any' do
-        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: :north)
+        rover = Rover.new(coordinates: Coordinates.new(0, 0), direction: Direction::NORTH)
 
         expect { rover.execute_commands(%w[f x]) }.to raise_error(ArgumentError)
         expect(rover.y).to eq(0)


### PR DESCRIPTION
## Summary
- Direction is now instantiable with private constructor and frozen constants (NORTH, SOUTH, EAST, WEST)
- Rover receives Direction objects directly via `direction:` parameter
- Rover calls `@direction.delta` instead of `Direction.delta_for(@direction)`

## Test plan
- [x] All 33 specs pass
- [x] Rubocop clean